### PR TITLE
Add options to listen method

### DIFF
--- a/comms.js
+++ b/comms.js
@@ -38,7 +38,14 @@ Comms.prototype.write = function(msg) {
 };
 
 Comms.prototype.listen = function(port) {
-	var self = this, server = this.server = jot.createServer(port);
+	var self = this, server;
+	
+	if (typeof port === 'number') {
+		server = this.server = jot.createServer();
+	} else {
+		server = this.server = jot.createServer(port);
+	}
+
 	server.on('connection', function(socket) {
 		socket.on('error', function(err) {
 			// ignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Basic IPC comms",
   "main": "comms.js",
   "bin": {


### PR DESCRIPTION
This will fix the `options must be an object` issue when running omnivore with node 6.9